### PR TITLE
Validata 0.2 compatibility

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 VUE_APP_VALIDATA_API_URL=http://localhost:5600
+VUE_APP_SCHEMAS_CATALOG_URL=https://schema.data.gouv.fr/schemas/schemas.json

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
 VUE_APP_VALIDATA_API_URL=https://api.validata.etalab.studio
+VUE_APP_SCHEMAS_CATALOG_URL=https://schema.data.gouv.fr/schemas/schemas.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -2767,8 +2767,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "coa": {
       "version": "2.0.2",
@@ -5036,8 +5035,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5058,14 +5056,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5080,20 +5076,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5210,8 +5203,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5223,7 +5215,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5238,7 +5229,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5246,14 +5236,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5272,7 +5260,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5353,8 +5340,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5366,7 +5352,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5452,8 +5437,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5489,7 +5473,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5509,7 +5492,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5553,14 +5535,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -9149,8 +9129,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="app">
       <b-container>
-          <h1>CSV generator</h1>
+          <h1>csv-gg</h1>
           <h4 class="text-muted">Générez un fichier CSV valide suivant un schéma</h4>
           <router-view/>
       </b-container>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -2,7 +2,7 @@
     <div>
         <b-form-group
           label="Choisissez un schéma à utiliser :"
-          :description="schemas && schemas[schemaName] ? schemas[schemaName].description : ''"
+          :description="schema && schema.description ? schema.description : ''"
           class="my-4"
         >
             <b-form-select v-model="schemaName" :options="options">
@@ -18,7 +18,7 @@
 <script>
 import SchemaForm from './SchemaForm.vue'
 
-const VALIDATA_API_URL = process.env.VUE_APP_VALIDATA_API_URL
+const SCHEMAS_CATALOG_URL = process.env.VUE_APP_SCHEMAS_CATALOG_URL
 
 export default {
   name: 'home',
@@ -32,15 +32,12 @@ export default {
   },
   mounted() {
       let loader = this.$loading.show()
-      fetch(`${VALIDATA_API_URL}/schemas`).then(r => {
+      fetch(`${SCHEMAS_CATALOG_URL}`).then(r => {
           return r.json()
       }).then(data => {
           this.schemas = data.schemas
-          this.options = Object.keys(this.schemas).map(schema => {
-              return {
-                  value: schema,
-                  text: this.schemas[schema].title
-              }
+          this.options = this.schemas.map(s => {
+              return {value: s.name, text: s.title || s.name}
           })
       }).finally(() => {
           loader.hide()
@@ -50,7 +47,7 @@ export default {
       schema() {
           if (!this.schemaName) return
           if (!this.schemas) return
-          return this.schemas[this.schemaName]
+          return this.schemas.find(s => s.name === this.schemaName)
       }
   },
   watch: {

--- a/src/views/SchemaForm.vue
+++ b/src/views/SchemaForm.vue
@@ -50,7 +50,7 @@ export default {
   },
   watch: {
       schemaMeta() {
-          // executing every time a new schema is choosen, except the first time
+          // executed every time a new schema is choosen, except the first time
           // reset everything (what a mess!)
           this.removeFieldNodes()
           this.lines = []
@@ -62,11 +62,11 @@ export default {
           this.errors = {}
           this.faultyFields = []
           // launch a new form build
-          this.buildForm(this.schemaMeta)
+          this.buildForm()
       }
   },
   mounted() {
-      this.buildForm(this.schemaMeta)
+      this.buildForm()
       EventBus.$on('field-value-changed', (field, value) => {
           this.values[field] = value
           this.computeHasValues()
@@ -108,7 +108,7 @@ export default {
   methods: {
       buildForm() {
           let loader = this.$loading.show();
-          fetch(this.schemaMeta.schema).then(r => {
+          fetch(this.schemaMeta.schema_url).then(r => {
               return r.json()
           }).then(data => {
               this.schema = data
@@ -152,7 +152,7 @@ export default {
           // Forcing UTF-8 encoding. See https://stackoverflow.com/questions/17879198
           var blob = new Blob(["\uFEFF" + this.buildCurrentCsvContent()], {type: 'text/csv'})
           formData.append('file', blob, 'data.csv')
-          formData.append('schema', this.schemaName)
+          formData.append('schema', this.schemaMeta.schema_url)
           return formData
       },
       removeFieldNodes() {


### PR DESCRIPTION
This makes csv-gg compatible with `validata-0.2`:
- makes use of an external `schemas.json` instead of relying on Validata API to fetch the list of schema
- adapts various parts to handle the new format of `schemas.json`

It should be compatible with https://github.com/etalab/schema.data.gouv.fr/pull/35 (use `title` and `description` if available).

We should not merge this before validata.etalab.studio is migrated to `validata-0.2`.