### PR TITLE
Ajout du contact contact@transport.beta.gouv.fr

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -22,6 +22,9 @@
                 </template>
             </b-form-select>
         </b-form-group>
+        <b-alert v-if="schema.name === 'etalab/schema-lieux-covoiturage'" show dismissible>
+            <div>Pour toute question, n'hésitez pas à adresser un mail à <a href="mailto:contact@transport.beta.gouv.fr">contact@transport.beta.gouv.fr</a></div>
+        </b-alert>
         <schema-form v-if="schema" :schema-meta="schema" :schema-name="schemaName"></schema-form>
     </div>
 </template>


### PR DESCRIPTION
Suite à la demande de l'équipe transport, je rajoute un message de contact en en-tête du formulaire "covoiturage". 

Cette opération est effectuée uniquement pour ce schéma.