### PR TITLE
Display only tableschemas schemas

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -50,7 +50,13 @@ export default {
       fetch(`${SCHEMAS_CATALOG_URL}`).then(r => {
           return r.json()
       }).then(data => {
-          this.schemas = data.schemas
+          let tableschemas = [];
+          data.schemas.forEach((schema) => {
+            if(schema.schema_type == 'tableschema') {
+              tableschemas.push(schema);
+            }
+          });
+          this.schemas = tableschemas;
           this.options = this.schemas.map(s => {
               return {value: s.name, text: s.title || s.name}
           })


### PR DESCRIPTION
Adaptation du code pour ne visualiser sur csv-gg que les schémas tableschemas (et ne pas tenir compte des autres format).

En lien avec https://framagit.org/opendataschema/catalog/-/merge_requests/3
